### PR TITLE
Fix/undefined names

### DIFF
--- a/python/example_aortic_arch.py
+++ b/python/example_aortic_arch.py
@@ -126,6 +126,7 @@ def createScene(root_node):
 
     # sofa-based controller
     controller_sofa = mcr_controller_sofa.ControllerSofa(
+        name='ControllerSofa',
         root_node=root_node,
         e_mns=navion,
         instrument=instrument,

--- a/python/example_flat.py
+++ b/python/example_flat.py
@@ -147,6 +147,7 @@ def createScene(root_node):
 
     # ros-based controller
     controller_sofa = mcr_controller_sofa.ControllerSofa(
+        name='ControllerSofa',
         root_node=root_node,
         e_mns=navion,
         instrument=instrument,

--- a/python/mcr_sim/mcr_controller_sofa.py
+++ b/python/mcr_sim/mcr_controller_sofa.py
@@ -43,6 +43,7 @@ class ControllerSofa(Sofa.Core.Controller):
         self.dfield_angle = 0.
 
         self.mag_controller = mcr_mag_controller.MagController(
+            name='mag_controller',
             root_node=self.root_node,
             e_mns=self.e_mns,
             instrument=self.instrument,

--- a/python/mcr_sim/mcr_instrument.py
+++ b/python/mcr_sim/mcr_instrument.py
@@ -171,12 +171,14 @@ class Instrument(Sofa.Core.Controller):
 
         self.CFF = self.InstrumentCombined.addObject(
             'ConstantForceField',
+            name='ConstantForceField',
             indices=indicesList,
             forces=forcesList,
             indexFromEnd=True)
 
         self.CFF_visu = self.InstrumentCombined.addObject(
             'ConstantForceField',
+            name='ConstantForceFieldViz',
             indices=0,
             force='0 0 0 0 0 0',
             showArrowSize=1.e2)


### PR DESCRIPTION
This PR sets names for some undefined sofa object names. This caused warnings when initializing the sofa scenes.